### PR TITLE
Endurance Test 1 and 2 failed due to a change from sb.append to sb.appen...

### DIFF
--- a/js/tests/enduranceTest.js
+++ b/js/tests/enduranceTest.js
@@ -53,9 +53,11 @@ var createOneShotTest = function(stream) {
 
     var xhr = runner.XHRManager.createRequest(stream.src,
       function(e) {
-        sb.append(xhr.getResponseData());
-        var end = util.Round(sb.buffered.end(0), 2);
+        sb.appendBuffer(xhr.getResponseData());
+        console.log("sb.buffered.length = "+sb.buffered.length)
+        var end = stream.duration;
         media.addEventListener('timeupdate', function(e) {
+          console.log("t = "+ media.currentTime + "end = " + end);
           if (!media.paused && media.currentTime > end - 1) {
             media.pause();
             runner.succeed();


### PR DESCRIPTION
...dBuffer in the function createOneShortTest

When we launch Endurance Test, the first tests stuck gets stuck on this trace is display in the console: 
CONSOLE: ErrorType: "Undefined" is not a function. Evaluating 'sb.append(xhr.getResponseData()')
There are 2 issues in this test: 
1. Variable 'sb' is a SourceBuffer and there's effectively no function 'append()' on such object; it's either 'appendBuffer()' or 'appendStream()'. The test seems completely outdated.
Solution : the call to append() is replaced by appendBuffer().
2. There are and issue with util.Round(sb.buffered.end(0), 2); It is necessary protecting that call with something like if (sb.buffered.lenght > 0) .