### PR TITLE
Fix inverted checks for WidevineSupport.

### DIFF
--- a/js/tests/2015/conformanceTest.js
+++ b/js/tests/2015/conformanceTest.js
@@ -1676,10 +1676,10 @@ testWidevineSupport.prototype.onsourceopen = function() {
 
   if (DoVideoTest('vp9', 'com.widevine.alpha') === '') {
     this.runner.checkEq(
-        video.canPlayType('video/mp4; codecs="avc1.640028"', 'com.widevine.alpha'), '',
+        video.canPlayType('video/mp4; codecs="avc1.640028"', 'com.widevine.alpha'), 'probably',
         'canPlayType result');
     this.runner.checkEq(
-        video.canPlayType('audio/mp4; codecs="mp4a.40.2"', 'com.widevine.alpha'), '',
+        video.canPlayType('audio/mp4; codecs="mp4a.40.2"', 'com.widevine.alpha'), 'probably',
         'canPlayType result');
 
     this.runner.succeed();

--- a/js/tests/tip/conformanceTest.js
+++ b/js/tests/tip/conformanceTest.js
@@ -1661,10 +1661,10 @@ testWidevineSupport.prototype.onsourceopen = function() {
 
   if (DoVideoTest('vp9', 'com.widevine.alpha') === '') {
     this.runner.checkEq(
-        video.canPlayType('video/mp4; codecs="avc1.640028"', 'com.widevine.alpha'), '',
+        video.canPlayType('video/mp4; codecs="avc1.640028"', 'com.widevine.alpha'), 'probably',
         'canPlayType result');
     this.runner.checkEq(
-        video.canPlayType('audio/mp4; codecs="mp4a.40.2"', 'com.widevine.alpha'), '',
+        video.canPlayType('audio/mp4; codecs="mp4a.40.2"', 'com.widevine.alpha'), 'probably',
         'canPlayType result');
 
     this.runner.succeed();


### PR DESCRIPTION
When the VP9 codec is not supported, the WidevineSupport test only
verifies that keySystem com.widevine.alpha handles codecs H264 and AAC.
However, those checks are inverted.