### PR TITLE
0001 check that handler has been processed to avoid race condition

### DIFF
--- a/js/lib/mse/2015/msutil.js
+++ b/js/lib/mse/2015/msutil.js
@@ -479,13 +479,16 @@ window.appendUntil = function(timeoutManager, mp, sb, chain, t, cb) {
     var appendCbs = 0;
     var shouldCallCb = false;
     var postAppendBufferCb = null;
+    var started = false;
 
     function startedAppendBuffer(cb) {
       totalAppends++;
       postAppendBufferCb = cb;
+      started = true;
     }
 
     function appendBufferFinished() {
+      if (!started) return;
       appendCbs++;
 
       buffered_end = findBufferedRangeEndForTime(sb, buffered_end);

--- a/js/lib/mse/tip/msutil.js
+++ b/js/lib/mse/tip/msutil.js
@@ -479,13 +479,16 @@ window.appendUntil = function(timeoutManager, mp, sb, chain, t, cb) {
     var appendCbs = 0;
     var shouldCallCb = false;
     var postAppendBufferCb = null;
+    var started = false;
 
     function startedAppendBuffer(cb) {
       totalAppends++;
       postAppendBufferCb = cb;
+      started = true;
     }
 
     function appendBufferFinished() {
+      if (!started) return;
       appendCbs++;
 
       buffered_end = findBufferedRangeEndForTime(sb, buffered_end);

--- a/js/tests/2013/enduranceTest.js
+++ b/js/tests/2013/enduranceTest.js
@@ -53,11 +53,9 @@ var createOneShotTest = function(stream) {
 
     var xhr = runner.XHRManager.createRequest(stream.src,
       function(e) {
-        sb.appendBuffer(xhr.getResponseData());
-        console.log("sb.buffered.length = "+sb.buffered.length)
-        var end = stream.duration;
+        sb.append(xhr.getResponseData());
+        var end = util.Round(sb.buffered.end(0), 2);
         media.addEventListener('timeupdate', function(e) {
-          console.log("t = "+ media.currentTime + "end = " + end);
           if (!media.paused && media.currentTime > end - 1) {
             media.pause();
             runner.succeed();

--- a/js/tests/2013/enduranceTest.js
+++ b/js/tests/2013/enduranceTest.js
@@ -53,9 +53,11 @@ var createOneShotTest = function(stream) {
 
     var xhr = runner.XHRManager.createRequest(stream.src,
       function(e) {
-        sb.append(xhr.getResponseData());
-        var end = util.Round(sb.buffered.end(0), 2);
+        sb.appendBuffer(xhr.getResponseData());
+        console.log("sb.buffered.length = "+sb.buffered.length)
+        var end = stream.duration;
         media.addEventListener('timeupdate', function(e) {
+          console.log("t = "+ media.currentTime + "end = " + end);
           if (!media.paused && media.currentTime > end - 1) {
             media.pause();
             runner.succeed();


### PR DESCRIPTION
There was an occasional flaky behaviour on some endurance test due to a delayed update event coming from appendInit who is triggering the appendBufferFinished() handler in appendUntil() ahead of time. So a delayed dispatching of update events is generating a race condition on appendInit. 

A change on the test would make appendBufferFinished() ignore update events coming before the initializer call to startAppendBuffer() to fix the issue. 

INVALID_STATE_ERR: DOM Exception 11: An attempt was made to use an object that is not, or is no longer, usable. 
Endurance Tests with this error
- InfiniteAVLoopTiny?
- InfiniteAVLoopNormal?
- InfiniteAVLoopHuge?