### PR TITLE
Revert "Add support to loop a test a number of times"

### DIFF
--- a/instructions.html
+++ b/instructions.html
@@ -58,10 +58,7 @@ limitations under the License.
         <span class='code'>
           <a href="tip.html?loop=true">
             tip.html?loop=true</a>
-        </span> to turn on loop
-            or <span class='code'><a href="tip.html?loop=10">
-            tip.html?loop=10</a></span> to run the test a certain
-            amount of times.
+        </span> to turn on loop.
       </li>
       <li>Use
         <span class='code'>

--- a/js/harness/main.js
+++ b/js/harness/main.js
@@ -56,17 +56,7 @@ var configureHarness = function(config) {
   TestBase.timeout = config.timeout;
   window.testid = config.testid;
   window.logging = config.disableLog !== 'true';
-  var loop;
-  if (config.loop === 'true')
-    loop = Number.POSITIVE_INFINITY;
-  else {
-    loop = Number.parseInt(config.loop);
-    if (!Number.isFinite(loop))
-      loop = 1;
-    else
-      loop = Math.max(1, loop);
-  }
-  window.loop = loop;
+  window.loop = config.loop === 'true';
   window.stoponfailure = config.stoponfailure === 'true';
   window.enablewebm = config.enablewebm === 'true';
 

--- a/js/harness/test.js
+++ b/js/harness/test.js
@@ -113,7 +113,6 @@ var TestRunner = function(testSuite, testsMask, testSuiteVer) {
   this.timeouts = createTimeoutManager(createLogger(this.log.bind(this)));
   this.lastResult = 'pass';
   this.testSuiteVer = testSuiteVer;
-  this.runCount = 0;
 
   if (testsMask) {
     this.testList = [];
@@ -272,10 +271,8 @@ TestRunner.prototype.onfinished = function() {
              this.longestTimeRatio + ' of its timeout.');
   }
 
-  ++this.runCount;
   var keepRunning = (!stoponfailure || this.lastResult === 'pass') &&
-    (this.runCount < loop) &&
-    (this.testView.anySelected() || this.numOfTestToRun === 1);
+      loop && (this.testView.anySelected() || this.numOfTestToRun === 1);
   if (keepRunning) {
     this.testToRun = this.numOfTestToRun;
     this.currentTestIdx = this.startIndex;


### PR DESCRIPTION
Reverts youtube/js_mse_eme#9

This change broke the loop functionality. Looping is always enabled by default with this change. This is unexpected behavior.