### PR TITLE
2016: do not add BMFF when not using ClearKey

### DIFF
--- a/js/lib/eme/2016/emeManager.js
+++ b/js/lib/eme/2016/emeManager.js
@@ -82,8 +82,10 @@ EMEHandler.prototype.onNeedKey = function(e) {
     throw 'Not initialized! Bad manifest parse?';
   }
 
+  var isClearKey = this.keySystem.toLowerCase() == "org.w3.clearkey";
+
   // Add clear key id to initData for gecko based browsers.
-  if (this.licenseManager.mime.indexOf('mp4') > -1 &&
+  if (isClearKey && this.licenseManager.mime.indexOf('mp4') > -1 &&
       !extractBMFFClearKeyID(e.initData)) {
     initData = addBMFFClearKeyID(e.initData, this.licenseManager.kids[0]);
   }


### PR DESCRIPTION
I guess this issue happens in more cases, not only 2016.

I am trying PlayReadyH264Video EME test in 2016 and I found that the key does not get generated because of a failure in that place. There's a JS error inside that if and that stops running, therefore the key does not get generated.

Another "funny" thing is that I am getting a 500 error from the server when the key is generated. Is everything ok there?