### PR TITLE
Support DOMHighResTimeStamp values in Event.timestamp

### DIFF
--- a/js/tests/2016/conformanceTest.js
+++ b/js/tests/2016/conformanceTest.js
@@ -1446,8 +1446,7 @@ testEventTimestamp.prototype.onsourceopen = function() {
   var video = this.video;
   var videoSb = this.ms.addSourceBuffer(StreamDef.VideoType);
   var audioSb = this.ms.addSourceBuffer(StreamDef.AudioType);
-  var last = Date.now();
-  runner.checkGr(last, 1360000000000, 'Date.now()');
+  var last = new Event('last').timeStamp;
 
   var audioXhr = runner.XHRManager.createRequest(StreamDef.AudioTiny.src,
       function(e) {


### PR DESCRIPTION
This fixes test "51. EventTimestamp" in the 2016 MSE test suite on browsers
implementing high resolution timestamps, as specified in[1]. Those timestamps
don't count from the epoch, but from the time origin[2].

This new behaviour is different from the specified in DOM4[3], where
Event.timestamp is of type DOMTimeStamp and is clearly stated that the epoch
is used as reference[4].

Most modern browsers (Firefox, Chrome, Edge and WebKit) have already migrated
to high res timestamps.

[1] https://dom.spec.whatwg.org/#interface-event
[2] https://w3c.github.io/hr-time/#time-origin
[3] https://www.w3.org/TR/domcore/#event
[4] https://www.w3.org/TR/domcore/#dom-event-timestamp