### PR TITLE
Fix Closed Captions keycode

### DIFF
--- a/js/harness/key.js
+++ b/js/harness/key.js
@@ -33,7 +33,7 @@ var keydb = {
   0x53:'Search',
   0xB1:'Previous',
   0xB0:'Next',
-  0xAF:'Closed Captions',
+  0x1CC:'Closed Captions',
   0x193:'Red',
   0x194:'Green',
   0x195:'Yellow',


### PR DESCRIPTION
In 2018 technical requirements:
9.0 Remote Keys and Key Events ->9.4.1 
Closed Captions / Subtitle (keyCode = 0x1CC)