### PR TITLE
Only measure time differences when the video has actually started playing

### DIFF
--- a/media/conformanceTest.js
+++ b/media/conformanceTest.js
@@ -633,6 +633,8 @@ var createCurrentTimePausedAccuracyTest =
 
       function onTimeUpdate(e) {
         if (times === 0) {
+          if (video.currentTime == 0)
+            return;
           baseTimeDiff = util.ElapsedTimeInS() - video.currentTime;
         }
         if (times > 500 || video.currentTime > 10) {


### PR DESCRIPTION
On some browsers (eg: WebKit), a timeUpdate event is emitted as soon as
video.play() is called, but that doesn't mean that the underlying media
framework has actually started to play right at that point (a startup delay
is expected on low end devices).

Therefore, the baseTimeDiff should be measured when video.currentTime has
actually progressed (becomes greater than zero).

I don't think that modifying the web engine to avoiding that initial
timeUpdate event is the right approach in this case, because that change
breaks our layout tests. In this specific case, modifying the MSE test to
start measuring baseTimeDiff in a better moment makes more sense. After
all, baseTimeDiff is retroactive, in the sense that it subtracts currentTime
so it doesn't matter if it's measured right at the begining of the playback
or some moments later, when time goes forward for the first time.