### PR TITLE
Add support for automated performance testing with Raptor

### DIFF
--- a/harness/main.js
+++ b/harness/main.js
@@ -50,6 +50,9 @@ var parseParams = function(testSuiteConfig) {
   config.testsMask = parseParam('tests_mask', '');
   config.testid = parseParam('testid', '');
 
+  // See: https://wiki.mozilla.org/Performance_sheriffing/Raptor
+  config.is_raptor = util.stringToBoolean(parseParam('raptor', false));
+
   config.is_cobalt = util.isCobalt();
   config.support_hdr = util.supportHdr();
   config.support_webgl = util.supportWebGL();

--- a/harness/test.js
+++ b/harness/test.js
@@ -296,6 +296,37 @@ TestExecutor.prototype.onfinished = function() {
       document.URL.indexOf('googleapis.com') >= 0) {
     this.sendTestReport(getTestResults());
   }
+
+  if (harnessConfig.is_raptor) {
+    function getRaptorTestResults(testStartId, testEndId) {
+      testStartId = testStartId || 0;
+      testEndId = testEndId || window.globalRunner.testList.length;
+
+      var results = {};
+      for (var i = testStartId; i < testEndId; ++i) {
+        var test = window.globalRunner.testList[i];
+        if (test) {
+          switch (harnessConfig.testType) {
+            case "playbackperf-test":
+              results[test.prototype.desc] = {
+                decodedFrames: test.prototype.decoded_frames,
+                droppedFrames: test.prototype.dropped_frames,
+              }
+            break;
+          }
+        }
+      }
+      return results;
+    };
+
+    let message = [
+      'raptor-benchmark',
+      'youtube-' + harnessConfig.testType,
+      getRaptorTestResults()
+    ];
+    this.log('sending youtube-' + harnessConfig.testType + ' results to Raptor');
+    window.postMessage(message, '*');
+  }
 };
 
 TestExecutor.prototype.sendTestReport = function(results) {
@@ -534,6 +565,4 @@ window.getTestResults = function(testStartId, testEndId) {
   }
   return results;
 };
-
-
 })();

--- a/media/playbackperfTest.js
+++ b/media/playbackperfTest.js
@@ -44,6 +44,9 @@ var createPerfTest = function(name, category, mandatory) {
   if (typeof mandatory === 'boolean') {
     t.prototype.mandatory = mandatory;
   }
+  t.prototype.dropped_frames = 0;
+  t.prototype.decoded_frames = 0;
+
   tests.push(t);
   return t;
 };
@@ -131,6 +134,8 @@ var createFrameDropValidationTest = function(videoStream1, videoStream2) {
         if (!video.paused && video.currentTime >= 15) {
           video.removeEventListener('timeupdate', onTimeUpdate);
           video.pause();
+          test.prototype.decoded_frames = totalDecodedFrames;
+          test.prototype.dropped_frames = totalDroppedFrames;
           if (totalDecodedFrames <= 0) {
             test.prototype.status = 'Fail';
             runner.fail('UserAgent was unable to render any frames.');
@@ -193,6 +198,8 @@ var createPlaybackPerfTest = function(
       if (!video.paused && video.currentTime >= 15) {
         video.removeEventListener('timeupdate', onTimeUpdate);
         video.pause();
+        test.prototype.decoded_frames = totalDecodedFrames;
+        test.prototype.dropped_frames = totalDroppedFrames;
         if (totalDecodedFrames <= 0) {
           test.prototype.status = 'Fail';
           runner.fail('UserAgent was unable to render any frames.');


### PR DESCRIPTION
Raptor is a performance-testing framework from Mozilla for
running browser pageload and browser benchmark tests.

The core of Raptor is an extension based on the WebExtension API,
therefore Raptor is cross-browser compatible and is currently
running in production on Firefox Desktop, Firefox Android GeckoView,
and on Google Chromium.

https://wiki.mozilla.org/Performance_sheriffing/Raptor