### PR TITLE
Allow playback of video to be muted (#41)

### DIFF
--- a/harness/main.js
+++ b/harness/main.js
@@ -44,6 +44,7 @@ var parseParams = function(testSuiteConfig) {
       parseParam('stoponfailure', false));
   config.enablewebm = util.stringToBoolean(
       parseParam('enablewebm', testSuiteConfig.enablewebm));
+  config.muted = util.stringToBoolean(parseParam('muted', false));
   config.novp9 = util.stringToBoolean(parseParam('novp9', false));
   config.tests = parseParam('tests');
   config.exclude = parseParam('exclude');
@@ -139,6 +140,7 @@ var createRunner = function(testSuite, testSuiteVer, testsMask) {
       testarea.innerHTML = '';
       testarea.appendChild(util.createElement('video', vid, 'box-right'));
       document.getElementById(vid).controls = true;
+      document.getElementById(vid).muted = harnessConfig.muted;
     }
     return document.getElementById(vid);
   };


### PR DESCRIPTION
Fixes issue #41.

For browsers / platforms where autoplay is blocked due to
audio output, allow the start of the playback by just
muting the audio channel.